### PR TITLE
fixes Cannot read properties of undefined (reading 'posinset') error

### DIFF
--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -1400,7 +1400,7 @@
         liData = liData || this.selectpicker.main.data[this.activeIndex];
         var a = li.firstChild;
 
-        if (a) {
+        if (liData && a) {
           a.setAttribute('aria-setsize', this.selectpicker.view.size);
           a.setAttribute('aria-posinset', liData.posinset);
 


### PR DESCRIPTION
when using live search, if a user enters a value that returns only non-selectable results, this error occurs. this commit fixes that error.